### PR TITLE
Potential fix for code scanning alert no. 3: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "vaul": "^1.1.0",
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "@replit/vite-plugin-runtime-error-modal": "^0.0.3",

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -6,12 +6,17 @@ import { exec, execFile as execFileCallback } from "child_process";
 import { promisify } from "util";
 import path from "path";
 import os from "os";
+import rateLimit from "express-rate-limit";
 
 const execFile = promisify(execFileCallback);
 const upload = multer({ dest: os.tmpdir() });
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
 
 export function registerRoutes(app: Express): Server {
-  app.post("/api/convert", upload.single("file"), async (req, res) => {
+  app.post("/api/convert", limiter, upload.single("file"), async (req, res) => {
     try {
       if (!req.file) {
         return res.status(400).send("No file uploaded");


### PR DESCRIPTION
Potential fix for [https://github.com/davisdre/File-Markdown-Converter/security/code-scanning/3](https://github.com/davisdre/File-Markdown-Converter/security/code-scanning/3)

To fix the problem, we need to introduce rate limiting to the route handler that performs the expensive operation. The best way to do this is by using the `express-rate-limit` middleware. This middleware will limit the number of requests that can be made to the route within a specified time window, thus preventing potential denial-of-service attacks.

We will:
1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `server/routes.ts` file.
3. Set up a rate limiter with appropriate configuration.
4. Apply the rate limiter to the specific route handler.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
