### PR TITLE
Potential fix for code scanning alert no. 4: Missing rate limiting

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,4 +1,5 @@
 import express, { type Express } from "express";
+import rateLimit from "express-rate-limit";
 import fs from "fs";
 import path, { dirname } from "path";
 import { fileURLToPath } from "url";
@@ -41,6 +42,14 @@ export async function setupVite(app: Express, server: Server) {
   });
 
   app.use(vite.middlewares);
+  
+  const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+  });
+  
+  app.use(limiter);
+  
   app.use("*", async (req, res, next) => {
     const url = req.originalUrl;
 


### PR DESCRIPTION
Potential fix for [https://github.com/davisdre/File-Markdown-Converter/security/code-scanning/4](https://github.com/davisdre/File-Markdown-Converter/security/code-scanning/4)

To fix the problem, we need to introduce rate limiting to the route handler that performs the file system access. We can use the `express-rate-limit` package to achieve this. The rate limiter will be configured to limit the number of requests to a reasonable number within a specified time window.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the file.
3. Configure the rate limiter with appropriate settings.
4. Apply the rate limiter to the route handler that performs the file system access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
