### PR TITLE
Potential fix for code scanning alert no. 5: Missing rate limiting

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -84,8 +84,14 @@ export function serveStatic(app: Express) {
 
   app.use(express.static(distPath));
 
+  // set up rate limiter: maximum of 100 requests per 15 minutes
+  const staticFileLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+  });
+
   // fall through to index.html if the file doesn't exist
-  app.use("*", (_req, res) => {
+  app.use("*", staticFileLimiter, (_req, res) => {
     res.sendFile(path.resolve(distPath, "index.html"));
   });
 }


### PR DESCRIPTION
Potential fix for [https://github.com/davisdre/File-Markdown-Converter/security/code-scanning/5](https://github.com/davisdre/File-Markdown-Converter/security/code-scanning/5)

To fix the problem, we need to introduce rate limiting to the route handler that performs the file system access. This can be achieved by using the `express-rate-limit` middleware, which is already imported in the file. We will create a rate limiter and apply it to the specific route handler that serves the static file.

1. Define a rate limiter with appropriate settings (e.g., maximum of 100 requests per 15 minutes).
2. Apply the rate limiter to the route handler that serves the static file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
