### PR TITLE
Potential fix for code scanning alert no. 6: Uncontrolled data used in path expression

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -23,9 +23,9 @@ export function registerRoutes(app: Express): Server {
       }
 
       // Validate the file path
-      const filePath = path.resolve(req.file.path);
+      const filePath = path.join(os.tmpdir(), path.basename(req.file.path));
       const realFilePath = await fs.realpath(filePath);
-      if (!realFilePath.startsWith(os.tmpdir())) {
+      if (!realFilePath.startsWith(os.tmpdir() + path.sep)) {
         return res.status(400).send("Invalid file path");
       }
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -23,8 +23,9 @@ export function registerRoutes(app: Express): Server {
       }
 
       // Validate the file path
-      const filePath = req.file.path;
-      if (!filePath.startsWith(os.tmpdir())) {
+      const filePath = path.resolve(req.file.path);
+      const realFilePath = await fs.realpath(filePath);
+      if (!realFilePath.startsWith(os.tmpdir())) {
         return res.status(400).send("Invalid file path");
       }
 


### PR DESCRIPTION
Potential fix for [https://github.com/davisdre/File-Markdown-Converter/security/code-scanning/6](https://github.com/davisdre/File-Markdown-Converter/security/code-scanning/6)

To fix the problem, we need to ensure that the file path is properly validated before using it. This involves normalizing the file path and checking that it is within the designated temporary directory. We can use the `path.resolve` and `fs.realpathSync` functions to achieve this.

1. Normalize the file path using `path.resolve` and `fs.realpathSync`.
2. Check that the normalized file path starts with the temporary directory path.
3. If the validation fails, return an error response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
