### PR TITLE
Potential fix for code scanning alert no. 6: Uncontrolled data used in path expression

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -34,7 +34,12 @@ export function registerRoutes(app: Express): Server {
       );
 
       // Clean up temp file
-      await fs.unlink(req.file.path);
+      const unlinkFilePath = path.join(os.tmpdir(), path.basename(req.file.path));
+      const realUnlinkFilePath = await fs.realpath(unlinkFilePath);
+      if (!realUnlinkFilePath.startsWith(os.tmpdir() + path.sep)) {
+        return res.status(400).send("Invalid file path");
+      }
+      await fs.unlink(realUnlinkFilePath);
 
       if (stderr) {
         console.error("Conversion error:", stderr);


### PR DESCRIPTION
Potential fix for [https://github.com/davisdre/File-Markdown-Converter/security/code-scanning/6](https://github.com/davisdre/File-Markdown-Converter/security/code-scanning/6)

To fix the problem, we need to ensure that the file path used in `fs.unlink` is properly validated and sanitized. We should use `path.resolve` and `fs.realpathSync` to normalize the path and ensure it is within the temporary directory. Additionally, we should use `path.basename` to strip any directory components from the file name, ensuring that only the file name is used.

1. Normalize the file path using `path.resolve` and `fs.realpathSync`.
2. Ensure the normalized path starts with the temporary directory path.
3. Use `path.basename` to ensure only the file name is used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
